### PR TITLE
Display the ispc-clean theme logo without the need to edit the config

### DIFF
--- a/interface/web/themes/ispc-clean/templates/main.tpl.htm
+++ b/interface/web/themes/ispc-clean/templates/main.tpl.htm
@@ -140,7 +140,7 @@
                         <tmpl_if name='usertype' op='==' value='normaluser'><input type="text" id="globalsearch" size="25" value="" /></tmpl_if>
                     </tmpl_if>
                 </nav>
-                <h1 id="ir-HeaderLogo" class="swap" style="background-image: url(<tmpl_var name='app_logo'>) !important"><span>ISPConfig 3</span></h1>
+                <h1 id="ir-HeaderLogo" class="swap" style="background-image: url(<tmpl_if name='app_logo' op='!=' value='themes/default/images/header_logo.png'><tmpl_var name='app_logo'><tmpl_else>themes/ispc-clean/images/header_logo.png</tmpl_if>) !important"><span>ISPConfig 3</span></h1>
                 <span class="sub-line">Hosting Control Panel</span>
             </header>
         </div>


### PR DESCRIPTION
A proposal for not need to edit the configuration file at all and simplify installation of clean theme. With this hack, you can easily switch the theme with the correct logo.